### PR TITLE
Fix for #6

### DIFF
--- a/src/main/java/net/creeperhost/chickens/client/render/RenderRoost.java
+++ b/src/main/java/net/creeperhost/chickens/client/render/RenderRoost.java
@@ -29,7 +29,13 @@ public class RenderRoost implements BlockEntityRenderer<BlockEntityRoost>
             ItemStack itemStack = blockEntityRoost.inventory.getStackInSlot(0);
 
             Minecraft mc = Minecraft.getInstance();
-            EntityType<?> entityType = Registry.ENTITY_TYPE.get(ResourceLocation.tryParse(ItemChicken.getTypeFromStack(itemStack)));
+            String chickenType = ItemChicken.getTypeFromStack(itemStack);
+            if (chickenType == null) return;
+            ResourceLocation location = ResourceLocation.tryParse(chickenType);
+            if (location == null) return;
+
+            EntityType<?> entityType = Registry.ENTITY_TYPE.get(location);
+
             EntityChickensChicken chicken = (EntityChickensChicken) entityType.create(Minecraft.getInstance().level);
             //Force the head rot in position to stop it bouncing
             chicken.yHeadRot = 0;


### PR DESCRIPTION
Roost block normally prevents non-chicken items from being inserted via the GUI; however, non-chicken items may be inserted via other means (hoppers, pipes from other mods, etc.). 

The render code (RenderRoost.java) did not have proper checks on the result of called nullable methods, causing a runtime exception. This PR adds a couple null checks, and returns early from the render method when appropriate.