### PR TITLE
Fixing tag Issue to prevent Minecraft client crashes

### DIFF
--- a/src/main/java/net/creeperhost/chickens/item/ItemColoredEgg.java
+++ b/src/main/java/net/creeperhost/chickens/item/ItemColoredEgg.java
@@ -35,6 +35,9 @@ public class ItemColoredEgg extends Item implements IColorSource
     {
         try
         {
+            if (!stack.hasTag()) {
+                return 0;
+            }
             int colourid = stack.getTag().getInt("colourid");
             DyeColor dyeColor = DyeColor.byId(colourid);
             if (dyeColor != null)


### PR DESCRIPTION
I have encountered a floating bug in the `Chickens` mod, as described in FTBTeam/FTB-Modpack-Issues#2207. Occasionally, an item from the `Chickens` mod sort of "loses" its tag, leading to potential issues when searching for `chickens`/`@chickens`/`egg` inside REI. This can cause the Minecraft client to freeze or crash due to excessive NPE's being logged. https://github.com/CreeperHost/Chickens/blob/822aae3ba5306caae3ccbb97a25e7790523b8e85/src/main/java/net/creeperhost/chickens/item/ItemColoredEgg.java#L44-L48
The problem seems to occur more frequently when playing on a server (localhost or remote), but can also happen offline. As of now I'm unable to identify broken item or reliably reproduce this issue.

This pull request addresses the issue by implementing a temporary fix. It involves checking for the existence of a tag and silently ignoring it if missing, instead of flooding the I/O and causing the game to become unresponsive. Although this solution is not ideal, it helps alleviate the problem until a more comprehensive resolution can be implemented. More error logs can be found at https://github.com/FTBTeam/FTB-Modpack-Issues/issues/2207#issuecomment-1336201494 