### PR TITLE
[1.20.4] Ensure that Chickens PolyEnergyBlocks do not overload power cables

### DIFF
--- a/common/src/main/java/net/creeperhost/chickens/blockentities/EggCrackerBlockEntity.java
+++ b/common/src/main/java/net/creeperhost/chickens/blockentities/EggCrackerBlockEntity.java
@@ -41,6 +41,7 @@ public class EggCrackerBlockEntity extends PolyBlockEntity implements ItemInvent
 
     public EggCrackerBlockEntity(BlockPos pos, BlockState state) {
         super(ModBlocks.EGG_CRACKER_TILE.get(), pos, state);
+        energy.setReceiveOnly();
     }
 
     @Override

--- a/common/src/main/java/net/creeperhost/chickens/blockentities/IncubatorBlockEntity.java
+++ b/common/src/main/java/net/creeperhost/chickens/blockentities/IncubatorBlockEntity.java
@@ -55,6 +55,7 @@ public class IncubatorBlockEntity extends PolyBlockEntity implements PolyFluidBl
 
     public IncubatorBlockEntity(BlockPos blockPos, BlockState blockState) {
         super(ModBlocks.INCUBATOR_TILE.get(), blockPos, blockState);
+        energy.setReceiveOnly();
     }
 
     @Override

--- a/common/src/main/java/net/creeperhost/chickens/blockentities/OvoscopeBlockEntity.java
+++ b/common/src/main/java/net/creeperhost/chickens/blockentities/OvoscopeBlockEntity.java
@@ -40,6 +40,7 @@ public class OvoscopeBlockEntity extends PolyBlockEntity implements ItemInventor
 
     public OvoscopeBlockEntity(BlockPos pos, BlockState state) {
         super(ModBlocks.OVOSCOPE_TILE.get(), pos, state);
+        energy.setReceiveOnly();
     }
 
     @Override


### PR DESCRIPTION
### Ticket
Addresses https://github.com/FTBTeam/FTB-Modpack-Issues/issues/5728

### Changes
For each of the 3 PolyEnergyBlocks (EggCrackerBlockEntity, IncubatorBlockEntity, and OvoscopeBlockEntity), set the PolyEnergyStorage to ReceiveOnly on construct. This will prevent the blocks from trying to export and receive power simultaneously, matching behavior of other energy blocks in the FTB Neotech modpack and preventing attached power cables from having their bandwidth consumed.

### Testing
Tested in a singleplayer world. I was able to reproduce the linked issue with the Chickens 2.0.6 and Chickens 2.0.7 release builds in the FTB Neotech modpack, but I was not able to reproduce when these changes are added.